### PR TITLE
Maintain Python 3.6 variable 'inline' type annotations as type comments

### DIFF
--- a/py_backwards/transformers/variables_annotations.py
+++ b/py_backwards/transformers/variables_annotations.py
@@ -9,13 +9,13 @@ class VariablesAnnotationsTransformer(BaseTransformer):
         b: int
     To:
         a = 10
-    
+
     """
     target = (3, 5)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> Optional[ast.Assign]:
         if node.value is None:
             return None
-
         return self.generic_visit(ast.Assign(targets=[node.target],  # type: ignore
-                                             value=node.value))
+                                             value=node.value,
+                                             type_comment=node.annotation))

--- a/tests/transformers/test_variables_annotations.py
+++ b/tests/transformers/test_variables_annotations.py
@@ -4,7 +4,7 @@ from ..utils import transform, run
 
 
 @pytest.mark.parametrize('before, after', [
-    ('a: int = 10', 'a = 10'),
+    ('a: int = 10', 'a = 10 # type: int'),
     ('a: int', '')])
 def test_transform(before, after):
     assert transform(VariablesAnnotationsTransformer, before) == after


### PR DESCRIPTION
Not sure if this is something you're remotely interested in, but this allows packages like MyPy to somewhat still function. 

Known issue of wrapping comments on longer lines to line above instead of MyPy-desired line below.