### PR TITLE
Support for converting keyword only arguments

### DIFF
--- a/py_backwards/transformers/__init__.py
+++ b/py_backwards/transformers/__init__.py
@@ -28,8 +28,8 @@ transformers = [
     YieldFromTransformer,
     ReturnFromGeneratorTransformer,
     # 2.7
-    FunctionsAnnotationsTransformer,
     KeywordOnlyArgumentsTransformer,
+    FunctionsAnnotationsTransformer,
     SuperWithoutArgumentsTransformer,
     ClassWithoutBasesTransformer,
     ImportPathlibTransformer,

--- a/py_backwards/transformers/__init__.py
+++ b/py_backwards/transformers/__init__.py
@@ -2,6 +2,7 @@ from typing import List, Type
 from .dict_unpacking import DictUnpackingTransformer
 from .formatted_values import FormattedValuesTransformer
 from .functions_annotations import FunctionsAnnotationsTransformer
+from .keyword_only_arguments import KeywordOnlyArgumentsTransformer
 from .starred_unpacking import StarredUnpackingTransformer
 from .variables_annotations import VariablesAnnotationsTransformer
 from .yield_from import YieldFromTransformer
@@ -28,6 +29,7 @@ transformers = [
     ReturnFromGeneratorTransformer,
     # 2.7
     FunctionsAnnotationsTransformer,
+    KeywordOnlyArgumentsTransformer,
     SuperWithoutArgumentsTransformer,
     ClassWithoutBasesTransformer,
     ImportPathlibTransformer,

--- a/py_backwards/transformers/keyword_only_arguments.py
+++ b/py_backwards/transformers/keyword_only_arguments.py
@@ -1,0 +1,38 @@
+from typed_ast import ast3 as ast
+from .base import BaseNodeTransformer
+
+
+class KeywordOnlyArgumentsTransformer(BaseNodeTransformer):
+    """Compiles:
+        def fn(x, *, a=None):
+            pass
+    To:
+        def fn(x, a=None):
+            pass
+
+    """
+    target = (2, 7)
+
+    def visit_arguments(self, node):
+        if node.kwonlyargs:
+            self._tree_changed = True
+
+            if node.defaults:
+                required_args = node.args[:-len(node.defaults)]
+                optional_args = node.args[-len(node.defaults):]
+            else:
+                required_args = node.args
+                optional_args = []
+
+            for kwarg, default in zip(node.kwonlyargs, node.kw_defaults):
+                if default is None:
+                    required_args.append(kwarg)
+                else:
+                    optional_args.append(kwarg)
+                    node.defaults.append(default)
+
+            node.args = required_args + optional_args
+            node.kwonlyargs = []
+            node.kw_defaults = []
+
+        return self.generic_visit(node)

--- a/py_backwards/transformers/keyword_only_arguments.py
+++ b/py_backwards/transformers/keyword_only_arguments.py
@@ -1,4 +1,3 @@
-from typed_ast import ast3 as ast
 from .base import BaseNodeTransformer
 
 


### PR DESCRIPTION
See: #16

There is no perfect way to convert those. This pull requests reorders arguments which might not be OK for some. But if you used keyword arguments for all arguments when calling, then this will continue to work in Python 2.7.